### PR TITLE
fixes compilation warnings in SimpleAccessTokens.kt:

### DIFF
--- a/src/test/kotlin/env/oauthserver/SimpleAccessTokens.kt
+++ b/src/test/kotlin/env/oauthserver/SimpleAccessTokens.kt
@@ -1,8 +1,8 @@
 package env.oauthserver
 
-import com.natpryce.Failure
-import com.natpryce.Result
-import com.natpryce.Success
+import dev.forkhandles.result4k.Failure
+import dev.forkhandles.result4k.Result
+import dev.forkhandles.result4k.Success
 import org.http4k.security.AccessToken
 import org.http4k.security.oauth.server.AccessTokens
 import org.http4k.security.oauth.server.AuthorizationCode


### PR DESCRIPTION
newer result4k has moved classes around - this PR should fix the following compiler warnings:

```src/test/kotlin/env/oauthserver/SimpleAccessTokens.kt:3:21: warning: 'typealias Failure<A> = Failure<A>' is deprecated. Repackaged
import com.natpryce.Failure
                    ^
src/test/kotlin/env/oauthserver/SimpleAccessTokens.kt:4:21: warning: 'typealias Result<A, B> = Result<A, B>' is deprecated. Repackaged
import com.natpryce.Result
                    ^
src/test/kotlin/env/oauthserver/SimpleAccessTokens.kt:5:21: warning: 'typealias Success<A> = Success<A>' is deprecated. Repackaged
import com.natpryce.Success
                    ^
src/test/kotlin/env/oauthserver/SimpleAccessTokens.kt:16:75: warning: 'typealias Failure<A> = Failure<A>' is deprecated. Repackaged
    override fun create(clientId: ClientId, tokenRequest: TokenRequest) = Failure(UnsupportedGrantType("client_credentials"))
                                                                          ^
src/test/kotlin/env/oauthserver/SimpleAccessTokens.kt:18:135: warning: 'typealias Result<A, B> = Result<A, B>' is deprecated. Repackaged
    override fun create(clientId: ClientId, tokenRequest: AuthorizationCodeAccessTokenRequest, authorizationCode: AuthorizationCode): Result<AccessToken, AuthorizationCodeAlreadyUsed> = Success(AccessToken(ACCESS_TOKEN_PREFIX + authorizationCode.value.reversed()))
                                                                                                                                      ^
src/test/kotlin/env/oauthserver/SimpleAccessTokens.kt:18:187: warning: 'typealias Success<A> = Success<A>' is deprecated. Repackaged
    override fun create(clientId: ClientId, tokenRequest: AuthorizationCodeAccessTokenRequest, authorizationCode: AuthorizationCode): Result<AccessToken, AuthorizationCodeAlreadyUsed> = Success(AccessToken(ACCESS_TOKEN_PREFIX + authorizationCode.value.reversed()))
```